### PR TITLE
Fix blind rotation wrap bug

### DIFF
--- a/Poker.Core.Tests/PokerEngineTests.cs
+++ b/Poker.Core.Tests/PokerEngineTests.cs
@@ -70,5 +70,27 @@ namespace Poker.Core.Tests
             Assert.Equal(totalBefore, totalAfter);
         }
 
+        [Fact]
+        public void NextHand_BlindPositionsWrapAround( )
+        {
+            var engine = new PokerEngine();
+            engine.SmallBlind = 1;
+            engine.BigBlind = 2;
+
+            var p1 = new Player("P1", startChips: 100, playerCount: 3, currentPosition: 0, new RandomAgent());
+            var p2 = new Player("P2", startChips: 100, playerCount: 3, currentPosition: 1, new RandomAgent());
+            var p3 = new Player("P3", startChips: 100, playerCount: 3, currentPosition: 2, new RandomAgent());
+
+            engine.Players = new List<Player> { p1, p2, p3 };
+
+            engine.SmallBlindPosition = 1;
+            engine.BigBlindPosition = 2;
+
+            engine.NextHand();
+
+            Assert.Equal(2, engine.SmallBlindPosition);
+            Assert.Equal(0, engine.BigBlindPosition);
+        }
+
     }
 }

--- a/Poker.Core/PokerEngine.cs
+++ b/Poker.Core/PokerEngine.cs
@@ -416,7 +416,7 @@ namespace Poker.Core
         private int _NextActiveFrom( int start )
         {
             var n = Players.Count;
-            var seat = start + 1 % n;
+            var seat = (start + 1) % n;
             while ( !ActivePlayerIndices.Contains(seat) )
                 seat = (seat + 1) % n;
             return seat;


### PR DESCRIPTION
## Summary
- fix `_NextActiveFrom` so modulo math works
- test blind position wrapping in `PokerEngine`

## Testing
- `dotnet test PokerWSS.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_683fc04e38ec8328a55fef5a52baa3bd